### PR TITLE
fix: mircosoft-edge-bin select files issue

### DIFF
--- a/src/filechooser/filechooser.c
+++ b/src/filechooser/filechooser.c
@@ -109,7 +109,7 @@ static int method_open_file(sd_bus_message *msg, void *data, sd_bus_error *ret_e
     }
     char *key;
     int inner_ret = 0;
-    int multiple, directory;
+    int multiple, directory = 0;
     while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
         inner_ret = sd_bus_message_read(msg, "s", &key);
         if (inner_ret < 0) {


### PR DESCRIPTION
Some Program or Applications doesn't send key `directory` on dbus when mode is select to file. 
![image](https://github.com/boydaihungst/xdg-desktop-portal-termfilechooser/assets/50710829/6b56fd3e-3871-413b-b83f-1370e6c8f43b)

This made `exec_filechooser` act little weird and print execution command
```
executing command: /home/<username>/.config/xdg-desktop-portal-termfilechooser/ranger-wrapper.sh 1 1 0 "" "/tmp/termfilechooser.portal"
```
like above. 

`multiple` flag and `directory` was set to true.

So I Just put initial value for directory