### PR TITLE
fix: make `directory` and `multiple` default to 0

### DIFF
--- a/src/filechooser/filechooser.c
+++ b/src/filechooser/filechooser.c
@@ -109,7 +109,7 @@ static int method_open_file(sd_bus_message *msg, void *data, sd_bus_error *ret_e
     }
     char *key;
     int inner_ret = 0;
-    int multiple, directory;
+    int multiple = 0, directory = 0;
     while ((ret = sd_bus_message_enter_container(msg, 'e', "sv")) > 0) {
         inner_ret = sd_bus_message_read(msg, "s", &key);
         if (inner_ret < 0) {


### PR DESCRIPTION
Currently, `directory` and `multiple` are left uninitialized in `method_open_file()`. This leads to them defaulting to `true` (most of the time – the real behavior is undefined) when the portal client omits those options in the D-Bus call. This changes them to correctly default to 0 instead. For reference, the program I ran into this bug with is VSCodium.