### PR TITLE
Fix link to ArchWiki XDG_Desktop_Portal configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If your xdg-desktop-portal version
     /usr/lib64/xdg-desktop-portal --version
     
 
-is >= [`1.18.0`](https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.18.0), then you can specify the portal for FileChooser in `~/.config/xdg-desktop-portal/portals.conf` file (see the [flatpak docs](https://flatpak.github.io/xdg-desktop-portal/docs/portals.conf.html) and [ArchWiki](wiki.archlinux.org/title/XDG_Desktop_Portal#Configuration)):
+is >= [`1.18.0`](https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.18.0), then you can specify the portal for FileChooser in `~/.config/xdg-desktop-portal/portals.conf` file (see the [flatpak docs](https://flatpak.github.io/xdg-desktop-portal/docs/portals.conf.html) and [ArchWiki](https://wiki.archlinux.org/title/XDG_Desktop_Portal#Configuration)):
 
     org.freedesktop.impl.portal.FileChooser=termfilechooser
 


### PR DESCRIPTION
Currently, points to https://github.com/boydaihungst/xdg-desktop-portal-termfilechooser/blob/main/wiki.archlinux.org/title/XDG_Desktop_Portal instead of https://wiki.archlinux.org/title/XDG_Desktop_Portal#Configuration