### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ If your xdg-desktop-portal version
 
 is >= [`1.18.0`](https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.18.0), then you can specify the portal for FileChooser in `~/.config/xdg-desktop-portal/portals.conf` file (see the [flatpak docs](https://flatpak.github.io/xdg-desktop-portal/docs/portals.conf.html) and [ArchWiki](https://wiki.archlinux.org/title/XDG_Desktop_Portal#Configuration)):
 
+    [preferred]
     org.freedesktop.impl.portal.FileChooser=termfilechooser
 
 If your `xdg-desktop-portal --version` is older, you can remove `FileChooser` from `Interfaces` of the `{gtk;kde;…}.portal` files:


### PR DESCRIPTION
Hey,

just a micro clarification in which section of *xdg-desktop-portal* config to add *FileChooser* option.
Before, I had no such config at all and I just pasted text below in it.
```
org.freedesktop.impl.portal.FileChooser=termfilechooser
```
So I spent some time to find issue before checking Arch Wiki....